### PR TITLE
rust-crypto-provider: disable pqc by default

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Build docs
         run: |
-          cargo doc --all-features --no-deps
+          cargo doc -F "std,serialization,hazmat,rustcrypto,libcrux" --no-deps
           touch target/doc/.nojekyll
           cat > target/doc/index.html <<EOF
           <!doctype html>

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,21 +31,21 @@ jobs:
       with:
         persist-credentials: false
     - name: Run tests all features
-      run: cargo test --verbose --no-default-features --all-features
+      run: cargo test --verbose --no-default-features -F "std,serialization,hazmat,rustcrypto,libcrux"
       # Release
     - name: Build Release
       run: cargo build --release --verbose
     - name: Run tests all features
-      run: cargo test --release --verbose --all-features
+      run: cargo test --release --verbose -F "std,serialization,hazmat,rustcrypto,libcrux"
       # Debug
     - name: Build Debug
       run: cargo build --verbose
     - name: Run tests all features
-      run: cargo test --verbose --all-features
+      run: cargo test --verbose -F "std,serialization,hazmat,rustcrypto,libcrux"
       # RC Provider
     - name: Build Debug RC provider all features
       working-directory: rust_crypto_provider
-      run: cargo build --verbose --all-features
+      run: cargo build --verbose -F "std"
     # Apple Silicon
     - if: matrix.os == 'macos-15-intel'
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serialization = ["serde", "tls_codec", "tls_codec/serde", "std"]
 hazmat = []
 rustcrypto = ["dep:hpke-rs-rust-crypto"]
 libcrux = ["dep:hpke-rs-libcrux"]
+experimental = ["hpke-rs-rust-crypto?/experimental"]
 
 hpke-test = ["std"]
 hpke-test-prng = [

--- a/rust_crypto_provider/CHANGELOG.md
+++ b/rust_crypto_provider/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-03-18
+
+### Changed
+
+- [#137](https://github.com/cryspen/hpke-rs/pull/137): Move unstable X-Wing and ML-KEM ciphersuites behind the `experimental` feature.
+
 ## [0.6.0] - 2026-02-13
 
 ### Fixed

--- a/rust_crypto_provider/Cargo.toml
+++ b/rust_crypto_provider/Cargo.toml
@@ -29,8 +29,10 @@ chacha20poly1305 = { version = "0.10", default-features = false, features = [
 ] }
 aes-gcm = { version = "0.10", default-features = false, features = ["aes"] }
 # Post-quantum KEMs
-x-wing = { version = "0.1.0-rc.0", default-features = false }
-ml-kem = { version = "0.3.0-rc.0", default-features = false }
+# XXX: These are broken and pre-releases. Dropping them until they are stable
+#      and someone actually wants to maintain them.
+x-wing = { version = "0.1.0-rc.0", default-features = false, optional = true }
+ml-kem = { version = "0.3.0-rc.0", default-features = false, optional = true }
 # Randomness
 rand_core = { version = "0.6", features = ["getrandom"] }
 rand_core_new = { version = "0.10", package = "rand_core", default-features = false }
@@ -49,6 +51,10 @@ deterministic-prng = [
     "hpke-rs-crypto/std",
     "rand_core/std",
 ] # ⚠️ FOR TESTING ONLY.
+experimental = [
+    "dep:x-wing",
+    "dep:ml-kem"
+]
 
 [[bench]]
 name = "bench_hkdf"

--- a/rust_crypto_provider/src/lib.rs
+++ b/rust_crypto_provider/src/lib.rs
@@ -27,6 +27,8 @@ use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret as X25519StaticSec
 
 mod aead;
 mod hkdf;
+// XXX: These are broken and pre-releases. Disabling them until they are stable.
+#[cfg(feature = "experimental")]
 mod pq_kem;
 use crate::aead::*;
 use crate::hkdf::*;
@@ -121,27 +123,32 @@ impl HpkeCrypto for HpkeRustCrypto {
         }
     }
 
-    fn kem_key_gen_derand(
-        alg: KemAlgorithm,
-        seed: &[u8],
-    ) -> Result<(Vec<u8>, Vec<u8>), Error> {
-        pq_kem::kem_key_gen_derand(alg, seed)
+    fn kem_key_gen_derand(_alg: KemAlgorithm, _seed: &[u8]) -> Result<(Vec<u8>, Vec<u8>), Error> {
+        // XXX: These are broken and pre-releases. Disabling them until they are stable.
+        #[cfg(feature = "experimental")]
+        return pq_kem::kem_key_gen_derand(_alg, _seed);
+
+        Err(Error::UnsupportedKemOperation)
     }
 
     fn kem_encaps(
-        alg: KemAlgorithm,
-        pk_r: &[u8],
-        prng: &mut Self::HpkePrng,
+        _alg: KemAlgorithm,
+        _pk_r: &[u8],
+        _prng: &mut Self::HpkePrng,
     ) -> Result<(Vec<u8>, Vec<u8>), Error> {
-        pq_kem::kem_encaps(alg, pk_r, prng)
+        // XXX: These are broken and pre-releases. Disabling them until they are stable.
+        #[cfg(feature = "experimental")]
+        return pq_kem::kem_encaps(alg, pk_r, prng);
+
+        Err(Error::UnsupportedKemOperation)
     }
 
-    fn kem_decaps(
-        alg: KemAlgorithm,
-        ct: &[u8],
-        sk_r: &[u8],
-    ) -> Result<Vec<u8>, Error> {
-        pq_kem::kem_decaps(alg, ct, sk_r)
+    fn kem_decaps(_alg: KemAlgorithm, _ct: &[u8], _sk_r: &[u8]) -> Result<Vec<u8>, Error> {
+        // XXX: These are broken and pre-releases. Disabling them until they are stable.
+        #[cfg(feature = "experimental")]
+        return pq_kem::kem_decaps(_alg, _ct, _sk_r);
+
+        Err(Error::UnsupportedKemOperation)
     }
 
     fn secret_to_public(alg: KemAlgorithm, sk: &[u8]) -> Result<Vec<u8>, Error> {
@@ -193,13 +200,14 @@ impl HpkeCrypto for HpkeRustCrypto {
                 let sk = sk.to_bytes().as_slice().into();
                 Ok((pk, sk))
             }
+            // XXX: These are broken and pre-releases. Disabling them until they
+            //      are stable.
             #[allow(deprecated)]
+            #[cfg(feature = "experimental")]
             KemAlgorithm::XWingDraft06
             | KemAlgorithm::XWingDraft06Obsolete
             | KemAlgorithm::MlKem768
-            | KemAlgorithm::MlKem1024 => {
-                pq_kem::kem_key_gen(alg, prng)
-            }
+            | KemAlgorithm::MlKem1024 => pq_kem::kem_key_gen(alg, prng),
             _ => Err(Error::UnknownKemAlgorithm),
         }
     }
@@ -272,12 +280,10 @@ impl HpkeCrypto for HpkeRustCrypto {
     /// Returns an error if the KEM algorithm is not supported by this crypto provider.
     fn supports_kem(alg: KemAlgorithm) -> Result<(), Error> {
         match alg {
-            KemAlgorithm::DhKem25519
-            | KemAlgorithm::DhKemP256
-            | KemAlgorithm::DhKemK256
-            | KemAlgorithm::XWingDraft06
-            | KemAlgorithm::MlKem768
-            | KemAlgorithm::MlKem1024 => Ok(()),
+            KemAlgorithm::DhKem25519 | KemAlgorithm::DhKemP256 | KemAlgorithm::DhKemK256 => Ok(()),
+            // XXX: These are broken and pre-releases. Disabling them until they are stable.
+            #[cfg(feature = "experimental")]
+            KemAlgorithm::XWingDraft06 | KemAlgorithm::MlKem768 | KemAlgorithm::MlKem1024 => Ok(()),
             _ => Err(Error::UnknownKemAlgorithm),
         }
     }
@@ -349,10 +355,7 @@ impl rand_core_new::TryRng for HpkeRustCryptoPrng {
         Ok(self.rng.next_u64())
     }
 
-    fn try_fill_bytes(
-        &mut self,
-        dst: &mut [u8],
-    ) -> Result<(), Self::Error> {
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
         self.rng.fill_bytes(dst);
         Ok(())
     }

--- a/rust_crypto_provider/src/lib.rs
+++ b/rust_crypto_provider/src/lib.rs
@@ -138,7 +138,7 @@ impl HpkeCrypto for HpkeRustCrypto {
     ) -> Result<(Vec<u8>, Vec<u8>), Error> {
         // XXX: These are broken and pre-releases. Disabling them until they are stable.
         #[cfg(feature = "experimental")]
-        return pq_kem::kem_encaps(alg, pk_r, prng);
+        return pq_kem::kem_encaps(_alg, _pk_r, _prng);
 
         Err(Error::UnsupportedKemOperation)
     }

--- a/tests/test_hpke.rs
+++ b/tests/test_hpke.rs
@@ -526,83 +526,88 @@ generate_test_case!(
     HpkeLibcrux
 );
 
-// X-Wing RustCrypto tests
-generate_test_case!(
-    base_xwingdraft06_hkdfsha256_chacha20poly1305_rustcrypto,
-    HpkeMode::Base,
-    KemAlgorithm::XWingDraft06,
-    KdfAlgorithm::HkdfSha256,
-    AeadAlgorithm::ChaCha20Poly1305,
-    HpkeRustCrypto
-);
-generate_test_case!(
-    base_xwingdraft06_hkdfsha256_Aes128Gcm_rustcrypto,
-    HpkeMode::Base,
-    KemAlgorithm::XWingDraft06,
-    KdfAlgorithm::HkdfSha256,
-    AeadAlgorithm::Aes128Gcm,
-    HpkeRustCrypto
-);
-generate_test_case!(
-    base_xwingdraft06_hkdfsha256_Aes256Gcm_rustcrypto,
-    HpkeMode::Base,
-    KemAlgorithm::XWingDraft06,
-    KdfAlgorithm::HkdfSha256,
-    AeadAlgorithm::Aes256Gcm,
-    HpkeRustCrypto
-);
+// XXX: These are broken and pre-releases. Disabling them until they are stable.
+#[cfg(feature = "experimental")]
+mod pq_kems {
 
-// ML-KEM-768 RustCrypto tests
-generate_test_case!(
-    base_mlkem768_hkdfsha256_chacha20poly1305_rustcrypto,
-    HpkeMode::Base,
-    KemAlgorithm::MlKem768,
-    KdfAlgorithm::HkdfSha256,
-    AeadAlgorithm::ChaCha20Poly1305,
-    HpkeRustCrypto
-);
-generate_test_case!(
-    base_mlkem768_hkdfsha256_Aes128Gcm_rustcrypto,
-    HpkeMode::Base,
-    KemAlgorithm::MlKem768,
-    KdfAlgorithm::HkdfSha256,
-    AeadAlgorithm::Aes128Gcm,
-    HpkeRustCrypto
-);
-generate_test_case!(
-    base_mlkem768_hkdfsha256_Aes256Gcm_rustcrypto,
-    HpkeMode::Base,
-    KemAlgorithm::MlKem768,
-    KdfAlgorithm::HkdfSha256,
-    AeadAlgorithm::Aes256Gcm,
-    HpkeRustCrypto
-);
+    // X-Wing RustCrypto tests
+    generate_test_case!(
+        base_xwingdraft06_hkdfsha256_chacha20poly1305_rustcrypto,
+        HpkeMode::Base,
+        KemAlgorithm::XWingDraft06,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeRustCrypto
+    );
+    generate_test_case!(
+        base_xwingdraft06_hkdfsha256_Aes128Gcm_rustcrypto,
+        HpkeMode::Base,
+        KemAlgorithm::XWingDraft06,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeRustCrypto
+    );
+    generate_test_case!(
+        base_xwingdraft06_hkdfsha256_Aes256Gcm_rustcrypto,
+        HpkeMode::Base,
+        KemAlgorithm::XWingDraft06,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeRustCrypto
+    );
 
-// ML-KEM-1024 RustCrypto tests
-generate_test_case!(
-    base_mlkem1024_hkdfsha256_chacha20poly1305_rustcrypto,
-    HpkeMode::Base,
-    KemAlgorithm::MlKem1024,
-    KdfAlgorithm::HkdfSha256,
-    AeadAlgorithm::ChaCha20Poly1305,
-    HpkeRustCrypto
-);
-generate_test_case!(
-    base_mlkem1024_hkdfsha256_Aes128Gcm_rustcrypto,
-    HpkeMode::Base,
-    KemAlgorithm::MlKem1024,
-    KdfAlgorithm::HkdfSha256,
-    AeadAlgorithm::Aes128Gcm,
-    HpkeRustCrypto
-);
-generate_test_case!(
-    base_mlkem1024_hkdfsha256_Aes256Gcm_rustcrypto,
-    HpkeMode::Base,
-    KemAlgorithm::MlKem1024,
-    KdfAlgorithm::HkdfSha256,
-    AeadAlgorithm::Aes256Gcm,
-    HpkeRustCrypto
-);
+    // ML-KEM-768 RustCrypto tests
+    generate_test_case!(
+        base_mlkem768_hkdfsha256_chacha20poly1305_rustcrypto,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeRustCrypto
+    );
+    generate_test_case!(
+        base_mlkem768_hkdfsha256_Aes128Gcm_rustcrypto,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeRustCrypto
+    );
+    generate_test_case!(
+        base_mlkem768_hkdfsha256_Aes256Gcm_rustcrypto,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeRustCrypto
+    );
+
+    // ML-KEM-1024 RustCrypto tests
+    generate_test_case!(
+        base_mlkem1024_hkdfsha256_chacha20poly1305_rustcrypto,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeRustCrypto
+    );
+    generate_test_case!(
+        base_mlkem1024_hkdfsha256_Aes128Gcm_rustcrypto,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeRustCrypto
+    );
+    generate_test_case!(
+        base_mlkem1024_hkdfsha256_Aes256Gcm_rustcrypto,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeRustCrypto
+    );
+}
 
 generate_test_case!(
     base_dhkemp256_hkdfsha384_chacha20poly1305,


### PR DESCRIPTION
Add `experimental` feature to enable these ciphersuites.

Note that the `experimental` feature does not compile right now.