### PR TITLE
feat: add libcrux provider support for P-384 and P-521 via RustCrypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ lazy_static = "1.4"
 rayon = "1.5"
 hpke-rs = { path = ".", features = ["hpke-test", "hazmat"] }
 hpke-rs-rust-crypto = { version = "0.6.1", path = "./rust_crypto_provider" }
-hpke-rs-libcrux = { version = "0.6.1", path = "./libcrux_provider", features = ["rustcrypto-p-curves"] }
+hpke-rs-libcrux = { version = "0.6.1", path = "./libcrux_provider" }
 rand = { version = "0.10" }
 pretty_env_logger = "0.5"
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serialization = ["serde", "tls_codec", "tls_codec/serde", "std"]
 hazmat = []
 rustcrypto = ["dep:hpke-rs-rust-crypto"]
 libcrux = ["dep:hpke-rs-libcrux"]
+libcrux-rustcrypto-p-curves = ["hpke-rs-libcrux?/rustcrypto-p-curves"]
 experimental = ["hpke-rs-rust-crypto?/experimental"]
 
 hpke-test = ["std"]
@@ -53,7 +54,7 @@ lazy_static = "1.4"
 rayon = "1.5"
 hpke-rs = { path = ".", features = ["hpke-test", "hazmat"] }
 hpke-rs-rust-crypto = { version = "0.6.1", path = "./rust_crypto_provider" }
-hpke-rs-libcrux = { version = "0.6.1", path = "./libcrux_provider" }
+hpke-rs-libcrux = { version = "0.6.1", path = "./libcrux_provider", features = ["rustcrypto-p-curves"] }
 rand = { version = "0.10" }
 pretty_env_logger = "0.5"
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/libcrux_provider/CHANGELOG.md
+++ b/libcrux_provider/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [#147](https://github.com/cryspen/hpke-rs/pull/147): Add P384 and P521 DHKEM support for the libcrux provider via RustCrypto crates guarded behind the `libcrux-rustcrypto-p-curves` feature flag.
+
 ## [0.6.1] - 2026-02-20
 
 ### Changed

--- a/libcrux_provider/Cargo.toml
+++ b/libcrux_provider/Cargo.toml
@@ -17,6 +17,8 @@ libcrux-kem = { version = "0.0.7", default-features = false }
 libcrux-aead = { version = "0.0.7" }
 libcrux-traits = { version = "0.0.6", default-features = false }
 # RustCrypto curves not available in libcrux
+# TODO: These should be replaced with libcrux implementations as soon as they
+# are available.
 p384 = { version = "0.14.0-rc.8", features = [
     "arithmetic",
     "ecdh",

--- a/libcrux_provider/Cargo.toml
+++ b/libcrux_provider/Cargo.toml
@@ -16,6 +16,15 @@ libcrux-hkdf = { version = "0.0.6" }
 libcrux-kem = { version = "0.0.7", default-features = false }
 libcrux-aead = { version = "0.0.7" }
 libcrux-traits = { version = "0.0.6", default-features = false }
+# RustCrypto curves not available in libcrux
+p384 = { version = "0.14.0-rc.8", features = [
+    "arithmetic",
+    "ecdh",
+], default-features = false, optional = true }
+p521 = { version = "0.14.0-rc.8", features = [
+    "arithmetic",
+    "ecdh",
+], default-features = false, optional = true }
 # Randomness
 rand = { version = "0.10", default-features = false, features = ["sys_rng"] }
 rand_core = { version = "0.10" }
@@ -27,6 +36,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 
 [features]
 deterministic-prng = [] # ⚠️ FOR TESTING ONLY.
+rustcrypto-p-curves = ["dep:p384", "dep:p521"]
 std = [
     "rand/std",
     "rand_chacha/std",

--- a/libcrux_provider/src/lib.rs
+++ b/libcrux_provider/src/lib.rs
@@ -169,8 +169,7 @@ impl HpkeCrypto for HpkeLibcrux {
         match alg {
             #[cfg(feature = "rustcrypto-p-curves")]
             KemAlgorithm::DhKemP384 => {
-                let chacha_seed: [u8; 32] =
-                    seed.try_into().map_err(|_| Error::InsufficientRandomness)?;
+                let chacha_seed = p_curve_key_gen_seed(alg, seed)?;
                 let mut rng = rand_chacha::ChaCha20Rng::from_seed(chacha_seed);
                 let sk = P384SecretKey::generate_from_rng(&mut rng);
                 let sk_bytes: Vec<u8> = sk.to_bytes().as_slice().into();
@@ -182,8 +181,7 @@ impl HpkeCrypto for HpkeLibcrux {
             }
             #[cfg(feature = "rustcrypto-p-curves")]
             KemAlgorithm::DhKemP521 => {
-                let chacha_seed: [u8; 32] =
-                    seed.try_into().map_err(|_| Error::InsufficientRandomness)?;
+                let chacha_seed = p_curve_key_gen_seed(alg, seed)?;
                 let mut rng = rand_chacha::ChaCha20Rng::from_seed(chacha_seed);
                 let sk = P521SecretKey::generate_from_rng(&mut rng);
                 let sk_bytes: Vec<u8> = sk.to_bytes().as_slice().into();
@@ -207,24 +205,48 @@ impl HpkeCrypto for HpkeLibcrux {
         pk_r: &[u8],
         prng: &mut Self::HpkePrng,
     ) -> Result<(Vec<u8>, Vec<u8>), Error> {
-        let alg = kem_key_type_to_libcrux_alg(alg)?;
+        match alg {
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP384 | KemAlgorithm::DhKemP521 => {
+                let (enc, sk_e) = <HpkeLibcrux as HpkeCrypto>::kem_key_gen(alg, prng)?;
+                let dh = <HpkeLibcrux as HpkeCrypto>::dh(alg, pk_r, &sk_e)?;
+                let kem_context = concat(&[&enc, pk_r]);
+                let ss = dh_kem_extract_and_expand(alg, &dh, &kem_context)?;
+                Ok((ss, enc))
+            }
+            _ => {
+                let alg = kem_key_type_to_libcrux_alg(alg)?;
 
-        let pk =
-            libcrux_kem::PublicKey::decode(alg, pk_r).map_err(|_| Error::KemInvalidPublicKey)?;
-        pk.encapsulate(prng)
-            .map_err(|e| Error::CryptoLibraryError(format!("Encaps error {:?}", e)))
-            .map(|(ss, ct)| (ss.encode(), ct.encode()))
+                let pk = libcrux_kem::PublicKey::decode(alg, pk_r)
+                    .map_err(|_| Error::KemInvalidPublicKey)?;
+                pk.encapsulate(prng)
+                    .map_err(|e| Error::CryptoLibraryError(format!("Encaps error {:?}", e)))
+                    .map(|(ss, ct)| (ss.encode(), ct.encode()))
+            }
+        }
     }
 
     fn kem_decaps(alg: KemAlgorithm, ct: &[u8], sk_r: &[u8]) -> Result<Vec<u8>, Error> {
-        let alg = kem_key_type_to_libcrux_alg(alg)?;
+        match alg {
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP384 | KemAlgorithm::DhKemP521 => {
+                let dh = <HpkeLibcrux as HpkeCrypto>::dh(alg, ct, sk_r)?;
+                let pk_r = <HpkeLibcrux as HpkeCrypto>::secret_to_public(alg, sk_r)?;
+                let kem_context = concat(&[ct, &pk_r]);
+                dh_kem_extract_and_expand(alg, &dh, &kem_context)
+            }
+            _ => {
+                let alg = kem_key_type_to_libcrux_alg(alg)?;
 
-        let ct = libcrux_kem::Ct::decode(alg, ct).map_err(|_| Error::AeadInvalidCiphertext)?;
-        let sk =
-            libcrux_kem::PrivateKey::decode(alg, sk_r).map_err(|_| Error::KemInvalidSecretKey)?;
-        ct.decapsulate(&sk)
-            .map_err(|e| Error::CryptoLibraryError(format!("Decaps error {:?}", e)))
-            .map(|ss| ss.encode())
+                let ct =
+                    libcrux_kem::Ct::decode(alg, ct).map_err(|_| Error::AeadInvalidCiphertext)?;
+                let sk = libcrux_kem::PrivateKey::decode(alg, sk_r)
+                    .map_err(|_| Error::KemInvalidSecretKey)?;
+                ct.decapsulate(&sk)
+                    .map_err(|e| Error::CryptoLibraryError(format!("Decaps error {:?}", e)))
+                    .map(|ss| ss.encode())
+            }
+        }
     }
 
     fn dh_validate_sk(alg: KemAlgorithm, sk: &[u8]) -> Result<Vec<u8>, Error> {
@@ -380,6 +402,81 @@ fn kem_ecdh_secret_to_public(alg: libcrux_ecdh::Algorithm, sk: &[u8]) -> Result<
         })
 }
 
+#[cfg(feature = "rustcrypto-p-curves")]
+#[inline(always)]
+fn dh_kem_extract_and_expand(
+    alg: KemAlgorithm,
+    dh: &[u8],
+    kem_context: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let kdf_alg: KdfAlgorithm = alg.into();
+    let suite_id = kem_suite_id(alg);
+    let eae_prk = labeled_extract(kdf_alg, &[], &suite_id, "eae_prk", dh)?;
+    labeled_expand(
+        kdf_alg,
+        &eae_prk,
+        &suite_id,
+        "shared_secret",
+        kem_context,
+        alg.shared_secret_len(),
+    )
+}
+
+#[cfg(feature = "rustcrypto-p-curves")]
+#[inline(always)]
+fn kem_suite_id(alg: KemAlgorithm) -> [u8; 5] {
+    let kem_id = (alg as u16).to_be_bytes();
+    [b'K', b'E', b'M', kem_id[0], kem_id[1]]
+}
+
+#[cfg(feature = "rustcrypto-p-curves")]
+#[inline(always)]
+fn labeled_extract(
+    alg: KdfAlgorithm,
+    salt: &[u8],
+    suite_id: &[u8],
+    label: &str,
+    ikm: &[u8],
+) -> Result<Vec<u8>, Error> {
+    const HPKE_VERSION: &[u8] = b"HPKE-v1";
+
+    let labeled_ikm = concat(&[HPKE_VERSION, suite_id, label.as_bytes(), ikm]);
+    <HpkeLibcrux as HpkeCrypto>::kdf_extract(alg, salt, &labeled_ikm)
+}
+
+#[cfg(feature = "rustcrypto-p-curves")]
+#[inline(always)]
+fn labeled_expand(
+    alg: KdfAlgorithm,
+    prk: &[u8],
+    suite_id: &[u8],
+    label: &str,
+    info: &[u8],
+    len: usize,
+) -> Result<Vec<u8>, Error> {
+    const HPKE_VERSION: &[u8] = b"HPKE-v1";
+
+    if len > u16::MAX.into() {
+        return Err(Error::HpkeInvalidOutputLength);
+    }
+
+    let len_bytes = (len as u16).to_be_bytes();
+    let labeled_info = concat(&[&len_bytes, HPKE_VERSION, suite_id, label.as_bytes(), info]);
+    <HpkeLibcrux as HpkeCrypto>::kdf_expand(alg, prk, &labeled_info, len)
+}
+
+#[cfg(feature = "rustcrypto-p-curves")]
+#[inline(always)]
+fn p_curve_key_gen_seed(alg: KemAlgorithm, seed: &[u8]) -> Result<[u8; 32], Error> {
+    if seed.len() != alg.private_key_len() {
+        return Err(Error::InsufficientRandomness);
+    }
+
+    <HpkeLibcrux as HpkeCrypto>::kdf_extract(KdfAlgorithm::HkdfSha256, &[], seed)?
+        .try_into()
+        .map_err(|_| Error::InsufficientRandomness)
+}
+
 /// Prepend 0x04 for uncompressed NIST curve points.
 #[inline(always)]
 fn nist_format_uncompressed(mut pk: Vec<u8>) -> Vec<u8> {
@@ -425,6 +522,12 @@ fn aead_alg(alg_type: AeadAlgorithm) -> Result<libcrux_aead::Aead, Error> {
         AeadAlgorithm::Aes256Gcm => Ok(libcrux_aead::Aead::AesGcm256),
         _ => Err(Error::UnknownAeadAlgorithm),
     }
+}
+
+#[cfg(feature = "rustcrypto-p-curves")]
+#[inline(always)]
+fn concat(values: &[&[u8]]) -> Vec<u8> {
+    values.join(&[][..])
 }
 
 impl hpke_rs_crypto::RngCore for HpkeLibcruxPrng {

--- a/libcrux_provider/src/lib.rs
+++ b/libcrux_provider/src/lib.rs
@@ -169,25 +169,29 @@ impl HpkeCrypto for HpkeLibcrux {
         match alg {
             #[cfg(feature = "rustcrypto-p-curves")]
             KemAlgorithm::DhKemP384 => {
-                let chacha_seed: [u8; 32] = seed
-                    .try_into()
-                    .map_err(|_| Error::InsufficientRandomness)?;
+                let chacha_seed: [u8; 32] =
+                    seed.try_into().map_err(|_| Error::InsufficientRandomness)?;
                 let mut rng = rand_chacha::ChaCha20Rng::from_seed(chacha_seed);
                 let sk = P384SecretKey::generate_from_rng(&mut rng);
+                let sk_bytes: Vec<u8> = sk.to_bytes().as_slice().into();
+                if sk_bytes.iter().all(|&b| b == 0) {
+                    return Err(Error::KemInvalidSecretKey);
+                }
                 let pk = sk.public_key().to_sec1_point(false).as_bytes().into();
-                let sk = sk.to_bytes().as_slice().into();
-                Ok((pk, sk))
+                Ok((pk, sk_bytes))
             }
             #[cfg(feature = "rustcrypto-p-curves")]
             KemAlgorithm::DhKemP521 => {
-                let chacha_seed: [u8; 32] = seed
-                    .try_into()
-                    .map_err(|_| Error::InsufficientRandomness)?;
+                let chacha_seed: [u8; 32] =
+                    seed.try_into().map_err(|_| Error::InsufficientRandomness)?;
                 let mut rng = rand_chacha::ChaCha20Rng::from_seed(chacha_seed);
                 let sk = P521SecretKey::generate_from_rng(&mut rng);
+                let sk_bytes: Vec<u8> = sk.to_bytes().as_slice().into();
+                if sk_bytes.iter().all(|&b| b == 0) {
+                    return Err(Error::KemInvalidSecretKey);
+                }
                 let pk = sk.public_key().to_sec1_point(false).as_bytes().into();
-                let sk = sk.to_bytes().as_slice().into();
-                Ok((pk, sk))
+                Ok((pk, sk_bytes))
             }
             _ => {
                 let alg = kem_key_type_to_libcrux_alg(alg)?;

--- a/libcrux_provider/src/lib.rs
+++ b/libcrux_provider/src/lib.rs
@@ -482,7 +482,9 @@ fn p_curve_key_gen_seed(alg: KemAlgorithm, seed: &[u8]) -> Result<[u8; 32], Erro
         return Err(Error::InsufficientRandomness);
     }
 
-    <HpkeLibcrux as HpkeCrypto>::kdf_extract(KdfAlgorithm::HkdfSha256, &[], seed)?
+    let kdf_alg: KdfAlgorithm = alg.into();
+    let extracted = <HpkeLibcrux as HpkeCrypto>::kdf_extract(kdf_alg, &[], seed)?;
+    extracted[..32]
         .try_into()
         .map_err(|_| Error::InsufficientRandomness)
 }

--- a/libcrux_provider/src/lib.rs
+++ b/libcrux_provider/src/lib.rs
@@ -168,8 +168,26 @@ impl HpkeCrypto for HpkeLibcrux {
     fn kem_key_gen_derand(alg: KemAlgorithm, seed: &[u8]) -> Result<(Vec<u8>, Vec<u8>), Error> {
         match alg {
             #[cfg(feature = "rustcrypto-p-curves")]
-            KemAlgorithm::DhKemP384 | KemAlgorithm::DhKemP521 => {
-                Err(Error::UnsupportedKemOperation)
+            KemAlgorithm::DhKemP384 => {
+                let chacha_seed: [u8; 32] = seed
+                    .try_into()
+                    .map_err(|_| Error::InsufficientRandomness)?;
+                let mut rng = rand_chacha::ChaCha20Rng::from_seed(chacha_seed);
+                let sk = P384SecretKey::generate_from_rng(&mut rng);
+                let pk = sk.public_key().to_sec1_point(false).as_bytes().into();
+                let sk = sk.to_bytes().as_slice().into();
+                Ok((pk, sk))
+            }
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP521 => {
+                let chacha_seed: [u8; 32] = seed
+                    .try_into()
+                    .map_err(|_| Error::InsufficientRandomness)?;
+                let mut rng = rand_chacha::ChaCha20Rng::from_seed(chacha_seed);
+                let sk = P521SecretKey::generate_from_rng(&mut rng);
+                let pk = sk.public_key().to_sec1_point(false).as_bytes().into();
+                let sk = sk.to_bytes().as_slice().into();
+                Ok((pk, sk))
             }
             _ => {
                 let alg = kem_key_type_to_libcrux_alg(alg)?;

--- a/libcrux_provider/src/lib.rs
+++ b/libcrux_provider/src/lib.rs
@@ -12,6 +12,17 @@ use hpke_rs_crypto::{
     CryptoRng, HpkeCrypto, HpkeTestRng,
 };
 
+#[cfg(feature = "rustcrypto-p-curves")]
+use p384::{
+    elliptic_curve::{ecdh::diffie_hellman as p384diffie_hellman, sec1::ToSec1Point, Generate},
+    PublicKey as P384PublicKey, SecretKey as P384SecretKey,
+};
+#[cfg(feature = "rustcrypto-p-curves")]
+use p521::{
+    elliptic_curve::ecdh::diffie_hellman as p521diffie_hellman, PublicKey as P521PublicKey,
+    SecretKey as P521SecretKey,
+};
+
 use rand::{rngs::SysRng, Rng, SeedableRng};
 use rand_core::UnwrapErr;
 
@@ -59,24 +70,61 @@ impl HpkeCrypto for HpkeLibcrux {
     }
 
     fn dh(alg: KemAlgorithm, pk: &[u8], sk: &[u8]) -> Result<Vec<u8>, Error> {
-        let alg = kem_key_type_to_ecdh_alg(alg)?;
+        match alg {
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP384 => {
+                let sk = P384SecretKey::from_slice(sk).map_err(|_| Error::KemInvalidSecretKey)?;
+                let pk =
+                    P384PublicKey::from_sec1_bytes(pk).map_err(|_| Error::KemInvalidPublicKey)?;
+                Ok(p384diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine())
+                    .raw_secret_bytes()
+                    .as_slice()
+                    .into())
+            }
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP521 => {
+                let sk = P521SecretKey::from_slice(sk).map_err(|_| Error::KemInvalidSecretKey)?;
+                let pk =
+                    P521PublicKey::from_sec1_bytes(pk).map_err(|_| Error::KemInvalidPublicKey)?;
+                Ok(p521diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine())
+                    .raw_secret_bytes()
+                    .as_slice()
+                    .into())
+            }
+            other => {
+                let alg = kem_key_type_to_ecdh_alg(other)?;
 
-        libcrux_ecdh::derive(alg, pk, sk)
-            .map_err(|e| Error::CryptoLibraryError(format!("ECDH derive error: {:?}", e)))
-            .map(|mut p| {
-                if alg == libcrux_ecdh::Algorithm::P256 {
-                    p.truncate(32);
-                    p
-                } else {
-                    p
-                }
-            })
+                libcrux_ecdh::derive(alg, pk, sk)
+                    .map_err(|e| Error::CryptoLibraryError(format!("ECDH derive error: {:?}", e)))
+                    .map(|mut p| {
+                        if alg == libcrux_ecdh::Algorithm::P256 {
+                            p.truncate(32);
+                            p
+                        } else {
+                            p
+                        }
+                    })
+            }
+        }
     }
 
     fn secret_to_public(alg: KemAlgorithm, sk: &[u8]) -> Result<Vec<u8>, Error> {
-        let alg = kem_key_type_to_ecdh_alg(alg)?;
-
-        kem_ecdh_secret_to_public(alg, sk)
+        match alg {
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP384 => {
+                let sk = P384SecretKey::from_slice(sk).map_err(|_| Error::KemInvalidSecretKey)?;
+                Ok(sk.public_key().to_sec1_point(false).as_bytes().into())
+            }
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP521 => {
+                let sk = P521SecretKey::from_slice(sk).map_err(|_| Error::KemInvalidSecretKey)?;
+                Ok(sk.public_key().to_sec1_point(false).as_bytes().into())
+            }
+            other => {
+                let alg = kem_key_type_to_ecdh_alg(other)?;
+                kem_ecdh_secret_to_public(alg, sk)
+            }
+        }
     }
 
     fn kem_key_gen(
@@ -89,8 +137,22 @@ impl HpkeCrypto for HpkeLibcrux {
                     .map(|(sk, pk)| (pk.encode(), sk.encode()))
                     .map_err(|e| Error::CryptoLibraryError(format!("KEM key gen error: {:?}", e)))
             }
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP384 => {
+                let sk = P384SecretKey::generate_from_rng(&mut prng.rng);
+                let pk = sk.public_key().to_sec1_point(false).as_bytes().into();
+                let sk = sk.to_bytes().as_slice().into();
+                Ok((pk, sk))
+            }
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP521 => {
+                let sk = P521SecretKey::generate_from_rng(&mut prng.rng);
+                let pk = sk.public_key().to_sec1_point(false).as_bytes().into();
+                let sk = sk.to_bytes().as_slice().into();
+                Ok((pk, sk))
+            }
             other_alg => {
-                // ECDH only
+                // ECDH only (libcrux curves)
                 let ecdh_alg = kem_key_type_to_ecdh_alg(other_alg)?;
                 let sk = libcrux_ecdh::generate_secret(ecdh_alg, prng).map_err(|e| {
                     Error::CryptoLibraryError(format!("KEM key gen error: {:?}", e))
@@ -104,11 +166,18 @@ impl HpkeCrypto for HpkeLibcrux {
     }
 
     fn kem_key_gen_derand(alg: KemAlgorithm, seed: &[u8]) -> Result<(Vec<u8>, Vec<u8>), Error> {
-        let alg = kem_key_type_to_libcrux_alg(alg)?;
-
-        libcrux_kem::key_gen_derand(alg, seed)
-            .map_err(|e| Error::CryptoLibraryError(format!("KEM key gen error: {:?}", e)))
-            .map(|(sk, pk)| (pk.encode(), sk.encode()))
+        match alg {
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP384 | KemAlgorithm::DhKemP521 => {
+                Err(Error::UnsupportedKemOperation)
+            }
+            _ => {
+                let alg = kem_key_type_to_libcrux_alg(alg)?;
+                libcrux_kem::key_gen_derand(alg, seed)
+                    .map_err(|e| Error::CryptoLibraryError(format!("KEM key gen error: {:?}", e)))
+                    .map(|(sk, pk)| (pk.encode(), sk.encode()))
+            }
+        }
     }
 
     fn kem_encaps(
@@ -138,9 +207,17 @@ impl HpkeCrypto for HpkeLibcrux {
 
     fn dh_validate_sk(alg: KemAlgorithm, sk: &[u8]) -> Result<Vec<u8>, Error> {
         match alg {
-            KemAlgorithm::DhKemP256 => libcrux_ecdh::p256::validate_scalar_slice(&sk)
+            KemAlgorithm::DhKemP256 => libcrux_ecdh::p256::validate_scalar_slice(sk)
                 .map_err(|e| Error::CryptoLibraryError(format!("ECDH invalid sk error: {:?}", e)))
                 .map(|sk| sk.0.to_vec()),
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP384 => P384SecretKey::from_slice(sk)
+                .map_err(|_| Error::KemInvalidSecretKey)
+                .map(|_| sk.into()),
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP521 => P521SecretKey::from_slice(sk)
+                .map_err(|_| Error::KemInvalidSecretKey)
+                .map(|_| sk.into()),
             _ => Err(Error::UnknownKemAlgorithm),
         }
     }
@@ -252,6 +329,8 @@ impl HpkeCrypto for HpkeLibcrux {
             KemAlgorithm::DhKem25519 | KemAlgorithm::DhKemP256 | KemAlgorithm::XWingDraft06 => {
                 Ok(())
             }
+            #[cfg(feature = "rustcrypto-p-curves")]
+            KemAlgorithm::DhKemP384 | KemAlgorithm::DhKemP521 => Ok(()),
             _ => Err(Error::UnknownKemAlgorithm),
         }
     }

--- a/src/dh_kem.rs
+++ b/src/dh_kem.rs
@@ -66,10 +66,18 @@ pub(super) fn derive_key_pair<Crypto: HpkeCrypto>(
             &[],
             alg.private_key_len(),
         )?),
-        KemAlgorithm::DhKemP256 | KemAlgorithm::DhKemK256 => {
+        KemAlgorithm::DhKemP256
+        | KemAlgorithm::DhKemP384
+        | KemAlgorithm::DhKemP521
+        | KemAlgorithm::DhKemK256 => {
+            // RFC 9180 §7.1.3: bitmask is 0x01 for P-521, 0xFF otherwise
+            let bitmask: u8 = match alg {
+                KemAlgorithm::DhKemP521 => 0x01,
+                _ => 0xFF,
+            };
             let mut ctr = 0u8;
             // Do rejection sampling trying to find a valid key.
-            // It is expected that there aren't too many iteration and that
+            // It is expected that there aren't too many iterations and that
             // the loop will always terminate.
             loop {
                 let candidate = labeled_expand::<Crypto>(
@@ -80,8 +88,9 @@ pub(super) fn derive_key_pair<Crypto: HpkeCrypto>(
                     &ctr.to_be_bytes(),
                     alg.private_key_len(),
                 );
-                if let Ok(sk) = &candidate {
-                    if let Ok(sk) = Crypto::dh_validate_sk(alg, sk) {
+                if let Ok(mut sk) = candidate {
+                    sk[0] &= bitmask;
+                    if let Ok(sk) = Crypto::dh_validate_sk(alg, &sk) {
                         break PrivateKey(sk);
                     }
                 }

--- a/tests/test_hpke.rs
+++ b/tests/test_hpke.rs
@@ -526,6 +526,108 @@ generate_test_case!(
     HpkeLibcrux
 );
 
+// P384/P521 via RustCrypto in the libcrux provider
+mod libcrux_p_curves {
+    use super::*;
+
+    generate_test_case!(
+        base_dhkemp384_hkdfsha384_Aes256Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::DhKemP384,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        base_dhkemp384_hkdfsha384_Aes128Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::DhKemP384,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        base_dhkemp384_hkdfsha384_chacha20poly1305_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::DhKemP384,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        base_dhkemp521_hkdfsha512_Aes256Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::DhKemP521,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        base_dhkemp521_hkdfsha512_Aes128Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::DhKemP521,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        base_dhkemp521_hkdfsha512_chacha20poly1305_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::DhKemP521,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        psk_dhkemp384_hkdfsha384_Aes256Gcm_libcrux,
+        HpkeMode::Psk,
+        KemAlgorithm::DhKemP384,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        psk_dhkemp521_hkdfsha512_Aes256Gcm_libcrux,
+        HpkeMode::Psk,
+        KemAlgorithm::DhKemP521,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        auth_dhkemp384_hkdfsha384_Aes256Gcm_libcrux,
+        HpkeMode::Auth,
+        KemAlgorithm::DhKemP384,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        auth_dhkemp521_hkdfsha512_Aes256Gcm_libcrux,
+        HpkeMode::Auth,
+        KemAlgorithm::DhKemP521,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        authpsk_dhkemp384_hkdfsha384_Aes256Gcm_libcrux,
+        HpkeMode::AuthPsk,
+        KemAlgorithm::DhKemP384,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+    generate_test_case!(
+        authpsk_dhkemp521_hkdfsha512_Aes256Gcm_libcrux,
+        HpkeMode::AuthPsk,
+        KemAlgorithm::DhKemP521,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+}
+
 // XXX: These are broken and pre-releases. Disabling them until they are stable.
 #[cfg(feature = "experimental")]
 mod pq_kems {

--- a/tests/test_hpke.rs
+++ b/tests/test_hpke.rs
@@ -527,8 +527,55 @@ generate_test_case!(
 );
 
 // P384/P521 via RustCrypto in the libcrux provider
+#[cfg(feature = "libcrux-rustcrypto-p-curves")]
 mod libcrux_p_curves {
     use super::*;
+
+    #[test]
+    fn kem_trait_roundtrip_p384_libcrux() {
+        let mut prng = HpkeLibcrux::prng();
+        let (pk_r, sk_r) = HpkeLibcrux::kem_key_gen(KemAlgorithm::DhKemP384, &mut prng).unwrap();
+        let (ss_enc, enc) =
+            HpkeLibcrux::kem_encaps(KemAlgorithm::DhKemP384, &pk_r, &mut prng).unwrap();
+        let ss_dec = HpkeLibcrux::kem_decaps(KemAlgorithm::DhKemP384, &enc, &sk_r).unwrap();
+        assert_eq!(ss_enc, ss_dec);
+    }
+
+    #[test]
+    fn kem_trait_roundtrip_p521_libcrux() {
+        let mut prng = HpkeLibcrux::prng();
+        let (pk_r, sk_r) = HpkeLibcrux::kem_key_gen(KemAlgorithm::DhKemP521, &mut prng).unwrap();
+        let (ss_enc, enc) =
+            HpkeLibcrux::kem_encaps(KemAlgorithm::DhKemP521, &pk_r, &mut prng).unwrap();
+        let ss_dec = HpkeLibcrux::kem_decaps(KemAlgorithm::DhKemP521, &enc, &sk_r).unwrap();
+        assert_eq!(ss_enc, ss_dec);
+    }
+
+    #[test]
+    fn kem_key_gen_derand_p384_uses_hpke_sized_seed_libcrux() {
+        let alg = KemAlgorithm::DhKemP384;
+        let seed = [0x42; 48];
+
+        let (pk, sk) = HpkeLibcrux::kem_key_gen_derand(alg, &seed).unwrap();
+        let (pk_repeat, sk_repeat) = HpkeLibcrux::kem_key_gen_derand(alg, &seed).unwrap();
+
+        assert_eq!(pk, pk_repeat);
+        assert_eq!(sk, sk_repeat);
+        assert_eq!(pk, HpkeLibcrux::secret_to_public(alg, &sk).unwrap());
+    }
+
+    #[test]
+    fn kem_key_gen_derand_p521_uses_hpke_sized_seed_libcrux() {
+        let alg = KemAlgorithm::DhKemP521;
+        let seed = [0x24; 66];
+
+        let (pk, sk) = HpkeLibcrux::kem_key_gen_derand(alg, &seed).unwrap();
+        let (pk_repeat, sk_repeat) = HpkeLibcrux::kem_key_gen_derand(alg, &seed).unwrap();
+
+        assert_eq!(pk, pk_repeat);
+        assert_eq!(sk, sk_repeat);
+        assert_eq!(pk, HpkeLibcrux::secret_to_public(alg, &sk).unwrap());
+    }
 
     generate_test_case!(
         base_dhkemp384_hkdfsha384_Aes256Gcm_libcrux,


### PR DESCRIPTION
This PR adds P384 and P521 DHKEM support for the libcrux provider via RustCrypto crates. Support is guarded behind the `libcrux-rustcrypto-p-curves` feature flag.